### PR TITLE
Support zipcode param; add third endpoint that returns both high-pri and nearby events

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ $ sls logs -f api --stage staging
 
 **Get Upcoming Events**
 
-Return a list of sorted events.
+Return a list of upcoming events ordered by priority then chronologically.
 
 ```
 GET /events/upcoming
@@ -60,16 +60,45 @@ Response (200/json)
 
 **Get Nearby Events**
 
-Get events near a given lat/lon coordinate within 300 miles.
+Return a list of events near within 300 miles of given lat/lon coordinate ordered strictly by geographic proximity (not by priority and not by time).
 
 ```
 GET /nearby?lat=${LATITUDE}&lon=${LONGITUDE}
+GET /nearby?zip=${ZIP}
 
 Response (200/json)
 {
   events: [
     {
-      distance: Float, // Miles from request coordinate
+      title: String,
+      date: String,
+      startTime: String,
+      endTime: String,
+      timezone: String,
+      publicAddress: String,
+      city: String,
+      state: String,
+      zipcode: String,
+      latitude: String,
+      longitude: String,
+      rsvpLink: String,
+    },
+  ],
+}
+
+**Get Upcoming High-Priority And Nearby Events**
+
+Return a list of upcoming events ordered by priority then by geographic
+proximity.
+
+```
+GET /upcoming-high-priority-and-nearby?lat=${LATITUDE}&lon=${LONGITUDE}
+GET /upcoming-high-priority-and-nearby?zip=${ZIP}
+
+Response (200/json)
+{
+  events: [
+    {
       title: String,
       date: String,
       startTime: String,

--- a/package-lock.json
+++ b/package-lock.json
@@ -2464,6 +2464,11 @@
           }
         }
       }
+    },
+    "zipcodes": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/zipcodes/-/zipcodes-8.0.0.tgz",
+      "integrity": "sha512-V8NolFaJhsPamGeCv5lJdk60Q7JBiXI6e+8JDksPC1NJWZ0t7g1OFfqVLZb2Nc2F5jmf9JTdYdWJBnIhGBvtbA=="
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
     "@ewarren/serverless-routing": "^1.2.3",
     "mongodb": "^3.2.3",
     "request": "^2.88.0",
-    "request-promise-native": "^1.0.7"
+    "request-promise-native": "^1.0.7",
+    "zipcodes": "^8.0.0"
   },
   "devDependencies": {
     "chai": "^4.2.0",

--- a/src/models/Event.js
+++ b/src/models/Event.js
@@ -29,6 +29,7 @@ const asyncWrap = require('../utils/asyncWrap');
 module.exports = (db) => {
   const collection = db.collection('events');
   const searchRadius = 300 * 1609;  // 300 miles in meters
+  const lowPriorityEventLimit = 25;  // Return no more than this many low-priority events.
 
   async function _init() {
     await collection.createIndex([ { startTime: 1 }, { highPriority: -1 }]);
@@ -84,7 +85,7 @@ module.exports = (db) => {
           $maxDistance: searchRadius
         }
       }
-    });
+    }).limit(lowPriorityEventLimit);
     const nearbyEvents = await eventsCursorNearby.toArray();
 
     return highPriorityEvents.concat(nearbyEvents)
@@ -113,7 +114,7 @@ module.exports = (db) => {
           $maxDistance: searchRadius
         }
       }
-    });
+    }).limit(lowPriorityEventLimit);
     return eventsCursor.toArray();
   }
 

--- a/src/models/Event.js
+++ b/src/models/Event.js
@@ -50,7 +50,7 @@ module.exports = (db) => {
       startTime: {
         $gte : new Date(),
       }
-    }).sort({ highPriority: -1, startTime: 1 });
+    }).sort({ highPriority: -1, startTime: 1 }).limit(lowPriorityEventLimit);
     return eventsCursor.toArray();
   }
 

--- a/src/routes/events.js
+++ b/src/routes/events.js
@@ -60,7 +60,7 @@ module.exports = (app) => {
     return success({ events: events.map(mongoDocumentToResponse) });
   });
 
-  app.get('/upcomingHighPriorityAndNearby', async ({ success, failed, event, context }) => {
+  app.get('/upcoming-high-priority-and-nearby', async ({ success, failed, event, context }) => {
     context.callbackWaitsForEmptyEventLoop = false;
     const db = await connectToDatabase();
     const { lat, lon } = parseLocParams(event);

--- a/test/routes/events.test.js
+++ b/test/routes/events.test.js
@@ -44,6 +44,9 @@ describe('events routes', function() {
         assert.equal(events.length, 5);
         assert.equal(events[0].title['en-US'], 'Tipton Meet & Greet with Elizabeth Warren');
         assert.equal(events[1].title['en-US'], 'Waukee for Warren Coffee Hours');
+        assert.equal(events[2].title['en-US'], 'Win with Warren Party MetroWest');
+        assert.equal(events[3].title['en-US'], 'Salem Community Meeting');
+        assert.equal(events[4].title['en-US'], 'Win with Warren Party Roxbury');
         assert.equal(new Date(events[0].date).getTimezoneOffset(), 0);
 
         done();
@@ -136,7 +139,7 @@ describe('events routes', function() {
     testDb.collection('events').insertMany(testEvents).then(() => {
       onRequest({
         httpMethod: 'get',
-        path: '/prod-events-v2/upcomingHighPriorityAndNearby',
+        path: '/prod-events-v2/upcoming-high-priority-and-nearby',
         queryStringParameters: {
           lat: '42.382393',
           lon: '-71.077814',
@@ -146,12 +149,14 @@ describe('events routes', function() {
         assert.equal(response.statusCode, 200);
         events = JSON.parse(response.body).events;
 
-        // Iowa event is excluded; Salem event is close enough but does not have lat/long in DB.
-        // Roxbury event is first because it's nearest.
-        assert.equal(events.length, 3);
+        assert.equal(events.length, 4);
+        // High priority events ordered chronologically, then low-priority
+        // events ordered by nearness.
+        // Only returns events with a lat/lon (so the Salem one is missing).
         assert.equal(events[0].title['en-US'], 'Tipton Meet & Greet with Elizabeth Warren');
         assert.equal(events[1].title['en-US'], 'Win with Warren Party Roxbury');
         assert.equal(events[2].title['en-US'], 'Win with Warren Party MetroWest');
+        assert.equal(events[3].title['en-US'], 'Waukee for Warren Coffee Hours');
         assert.equal(new Date(events[0].date).getTimezoneOffset(), 0);
 
         done();


### PR DESCRIPTION
1. add ?zip=02145 param that can be used instead of lat/lon
2. add a third endpoint `/upcomingHighPriorityAndNearby?zip=02145` which returns first high-priority events ordered chronologically, then all events by ordered by proximity.