### PR TITLE
Log ip and user agent for all requests

### DIFF
--- a/src/routes/events.js
+++ b/src/routes/events.js
@@ -28,8 +28,20 @@ function parseLocParams(event) {
 }
 
 module.exports = (app) => {
-  app.get('/upcoming', async ({ success, failed, context }) => {
+  app.get('/upcoming', async ({ event, success, failed, context }) => {
     context.callbackWaitsForEmptyEventLoop = false;
+
+    const {
+      requestContext: {
+        identity: {
+          sourceIp,
+          userAgent,
+        },
+      },
+    } = event;
+
+    console.log('Incoming request', { path: '/upcoming', sourceIp, userAgent });
+
     const db = await connectToDatabase();
     const Event = EventModel(db);
     const upcomingEvents = await Event.getUpcomingEvents();
@@ -43,6 +55,18 @@ module.exports = (app) => {
 
   app.get('/nearby', async ({ success, failed, event, context }) => {
     context.callbackWaitsForEmptyEventLoop = false;
+
+    const {
+      requestContext: {
+        identity: {
+          sourceIp,
+          userAgent,
+        },
+      },
+    } = event;
+
+    console.log('Incoming request', { path: '/upcoming', sourceIp, userAgent });
+
     const db = await connectToDatabase();
     const { lat, lon } = parseLocParams(event);
 
@@ -62,6 +86,18 @@ module.exports = (app) => {
 
   app.get('/upcoming-high-priority-and-nearby', async ({ success, failed, event, context }) => {
     context.callbackWaitsForEmptyEventLoop = false;
+
+    const {
+      requestContext: {
+        identity: {
+          sourceIp,
+          userAgent,
+        },
+      },
+    } = event;
+
+    console.log('Incoming request', { path: '/upcoming', sourceIp, userAgent });
+
     const db = await connectToDatabase();
     const { lat, lon } = parseLocParams(event);
 


### PR DESCRIPTION
I should add this to [serverless-routing](https://github.com/elizabeth-warren/serverless-routing) but just doing this real quick for now to address the problem

Here is the proxy documentation where I get the parameters from, https://docs.aws.amazon.com/apigateway/latest/developerguide/set-up-lambda-proxy-integrations.html

We grab the `sourceIp` in the [personalization-ap herei](https://github.com/Elizabeth-Warren/personalization-api/blob/master/src/routes/location.js#L26)