### PR TITLE
Include eventType in response; don't include full events

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,8 @@ Response (200/json)
       latitude: String,
       longitude: String,
       rsvpLink: String,
+      highPriority: Bool,
+      eventType: String,
     },
   ],
 }
@@ -82,6 +84,8 @@ Response (200/json)
       latitude: String,
       longitude: String,
       rsvpLink: String,
+      highPriority: Bool,
+      eventType: String,
     },
   ],
 }
@@ -111,6 +115,8 @@ Response (200/json)
       latitude: String,
       longitude: String,
       rsvpLink: String,
+      highPriority: Bool,
+      eventType: String,
     },
   ],
 }

--- a/src/tasks/importEvents.js
+++ b/src/tasks/importEvents.js
@@ -10,7 +10,7 @@ function promotedOrganizationsUrl() {
 }
 
 function organizationEventsUrl(organizationId) {
-  return `https://api.mobilize.us/v1/organizations/${organizationId}/events?timeslot_start=gte_now`;
+  return `https://api.mobilize.us/v1/organizations/${organizationId}/events?timeslot_start=gte_now&exclude_full=true`;
 }
 
 const mobilizeAmericaApiKey = process.env.MOBILIZE_AMERICA_API_KEY;

--- a/src/transformers/event.js
+++ b/src/transformers/event.js
@@ -25,6 +25,7 @@ function mongoDocumentToResponse({
   highPriority,
   rsvpLink,
   rsvpCtaOverride,
+  eventType,
 }) {
   return {
     title,
@@ -42,6 +43,7 @@ function mongoDocumentToResponse({
     highPriority,
     rsvpLink,
     rsvpCtaOverride,
+    eventType,
   };
 };
 
@@ -53,6 +55,7 @@ function mobilizeAmericaToMongoDocument({
   timezone,
   browser_url,
   high_priority,
+  event_type,
 }) {
   return {
     mobilizeId: id,
@@ -79,6 +82,7 @@ function mobilizeAmericaToMongoDocument({
     rsvpLink: browser_url.replace(new RegExp('www.mobilize.us/[^/]+'), 'events.elizabethwarren.com'),
     rsvpCtaOverride: null,
     highPriority: high_priority,
+    eventType: event_type,
   };
 };
 

--- a/test/fixtures/events.js
+++ b/test/fixtures/events.js
@@ -16,6 +16,7 @@ module.exports = [{
     rsvpLink: 'https://events.elizabethwarren.com/event/88773/',
     rsvpCtaOverride: null,
     highPriority: false,
+    eventType: 'COMMUNITY',
   }, {
     mobilizeId: 90980,
     loc: { type: 'Point', coordinates: [-91.1281814, 41.7687331] },
@@ -35,6 +36,7 @@ module.exports = [{
     rsvpLink: 'https://events.elizabethwarren.com/event/90980/',
     rsvpCtaOverride: null,
     highPriority: true,
+    eventType: 'MEET_GREET',
   }, {
     mobilizeId: 90805,
     loc: null,  // Some Mobilize America events do not have lat/long.
@@ -53,6 +55,7 @@ module.exports = [{
     rsvpLink: 'https://events.elizabethwarren.com/event/90805/',
     rsvpCtaOverride: null,
     highPriority: false,
+    eventType: 'COMMUNITY',
   }, {
     mobilizeId: 88931,
     loc: { type: 'Point', coordinates: [-71.6080009, 42.2638905] },
@@ -71,6 +74,7 @@ module.exports = [{
     rsvpLink: 'https://events.elizabethwarren.com/event/88931/',
     rsvpCtaOverride: null,
     highPriority: false,
+    eventType: 'COMMUNITY',
   }, {
     mobilizeId: 89109,
     loc: { type: 'Point', coordinates: [-71.0953117, 42.326097] },
@@ -89,4 +93,5 @@ module.exports = [{
     rsvpLink: 'https://events.elizabethwarren.com/event/89109/',
     rsvpCtaOverride: null,
     highPriority: false,
+    eventType: 'COMMUNITY',
   }]

--- a/test/routes/events.test.js
+++ b/test/routes/events.test.js
@@ -47,7 +47,9 @@ describe('events routes', function() {
         assert.equal(events[2].title['en-US'], 'Win with Warren Party MetroWest');
         assert.equal(events[3].title['en-US'], 'Salem Community Meeting');
         assert.equal(events[4].title['en-US'], 'Win with Warren Party Roxbury');
+
         assert.equal(new Date(events[0].date).getTimezoneOffset(), 0);
+        assert.equal(events[0].eventType, 'MEET_GREET');
 
         done();
       });

--- a/test/tasks/importEvents.test.js
+++ b/test/tasks/importEvents.test.js
@@ -79,7 +79,7 @@ describe('importEvents task', function() {
       .get('/v1/organizations/1316/promoted_organizations')
       .reply(200, require('../fixtures/mobilizeamerica/promoted_organizations.json'));
     nock(mobilizeAmericaBase)
-      .get('/v1/organizations/1310/events?timeslot_start=gte_now')
+      .get('/v1/organizations/1310/events?timeslot_start=gte_now&exclude_full=true')
       .reply(200, require('../fixtures/mobilizeamerica/1310-1.json'));
     nock(mobilizeAmericaBase)
       .get('/v1/organizations/1310/events?page=2&timeslot_start=gte_now')
@@ -88,16 +88,16 @@ describe('importEvents task', function() {
       .get('/v1/organizations/1310/events?page=3&timeslot_start=gte_now')
       .reply(200, require('../fixtures/mobilizeamerica/1310-3.json'));
     nock(mobilizeAmericaBase)
-      .get('/v1/organizations/1361/events?timeslot_start=gte_now')
+      .get('/v1/organizations/1361/events?timeslot_start=gte_now&exclude_full=true')
       .reply(200, require('../fixtures/mobilizeamerica/1361-1.json'));
     nock(mobilizeAmericaBase)
-      .get('/v1/organizations/1416/events?timeslot_start=gte_now')
+      .get('/v1/organizations/1416/events?timeslot_start=gte_now&exclude_full=true')
       .reply(200, require('../fixtures/mobilizeamerica/1416-1.json'));
     nock(mobilizeAmericaBase)
-      .get('/v1/organizations/1360/events?timeslot_start=gte_now')
+      .get('/v1/organizations/1360/events?timeslot_start=gte_now&exclude_full=true')
       .reply(200, require('../fixtures/mobilizeamerica/1360-1.json'));
     nock(mobilizeAmericaBase)
-      .get('/v1/organizations/1316/events?timeslot_start=gte_now')
+      .get('/v1/organizations/1316/events?timeslot_start=gte_now&exclude_full=true')
       .reply(200, require('../fixtures/mobilizeamerica/1316-1.json'));
     nock(mobilizeAmericaBase)
       .get('/v1/organizations/1316/events?page=2&timeslot_start=gte_now')
@@ -137,6 +137,7 @@ describe('importEvents task', function() {
     // but not in the top-level organization. It should be pulled down as high
     // priority because the state organization setting takes precedence.
     assert.equal(updatedEvent.highPriority, true);
+    assert.equal(updatedEvent.eventType, 'MEET_GREET');
 
     obsoleteEventExists = await collection.count({ mobilizeId: 1234 })
     assert.equal(obsoleteEventExists, 0);


### PR DESCRIPTION
1. We were surfacing full events; now we'll only import not full events, using `exclude_full=true` when we hit Mobilize America API.
2. Adds `eventType` to response, if we want to style or surface event type at some point. (I want candidates to be able to rank/style based on this if they want, in our interview questions.)