### PR TITLE
Simplify importEvents so we only look at national org events.

### DIFF
--- a/src/tasks/importEvents.js
+++ b/src/tasks/importEvents.js
@@ -27,9 +27,15 @@ async function mobilizeAmericaRequest(url) {
 }
 
 async function getPromotedOrganizations() {
+  // As of Oct 2019, we're simply presenting the national organization's events
+  // feed as-is without special handling of promoted organizations.
+  return [];
+
+  /*
   const body = await mobilizeAmericaRequest(promotedOrganizationsUrl());
   const organizationIds = body.data.map(({ id }) => id);
   return organizationIds;
+  */
 }
 
 async function getEventsForOrganization(organizationId) {
@@ -61,18 +67,6 @@ async function getAllEvents() {
     for (let organizationEvents of nestedEvents) {
       for (let organizationEvent of organizationEvents) {
         if (!alreadyAddedEvents.has(organizationEvent.id)) {
-          // This is a bit sloppy. Historically, we wanted events marked as
-          // high-priority in suborganizations (i.e. Iowa, New Hampshire, etc)
-          // to be marked as high priorty on the website. In October 2019 we
-          // decided that only events marked as high priority in national
-          // organization should be high priority on the website. So we don't
-          // let any events from non-National organizations be high priority.
-          // With this new behavior, we really should just refactor this entire
-          // import so it only fetches events from the National instance.
-          if (organizationEvent.sponsor.id != topLevelOrganizationId) {
-            organizationEvent.high_priority = false
-          }
-
           flatEvents.push(organizationEvent);
           alreadyAddedEvents.add(organizationEvent.id);
         }

--- a/test/tasks/importEvents.test.js
+++ b/test/tasks/importEvents.test.js
@@ -150,6 +150,6 @@ describe('importEvents task', function() {
 
     const eventsCursor = await collection.find().sort( { startTime: 1 } );
     const allEvents = await eventsCursor.toArray();
-    assert.equal(allEvents.length, 159);
+    assert.equal(allEvents.length, 150);
   });
 });


### PR DESCRIPTION
My last attempt at this wasn't right because we *do* want promoted organizations' events to be able to be high priority. The right approach is just to only look at national organization event feed.