### PR TITLE
fix README formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ Response (200/json)
     },
   ],
 }
+```
 
 **Get Upcoming High-Priority And Nearby Events**
 


### PR DESCRIPTION
The `GET /nearby` code block was missing a closing "```".