### PR TITLE
update .dockerignore to ignore unnecessary objects

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,1 +1,17 @@
 node_modules/
+.github/
+.gitignore
+docker-compose.yml
+Dockerfile
+LICENSE
+Makefile
+README.md
+serverless.yml
+
+# package directories
+node_modules
+jspm_packages
+
+# artifacts
+.serverless
+data/


### PR DESCRIPTION
This prevents accidently `COPY`ing the `./data` volume the mongo instance uses.